### PR TITLE
allow missing bmi

### DIFF
--- a/R/predict_risk.R
+++ b/R/predict_risk.R
@@ -913,6 +913,8 @@ predict_30yr_stroke_risk <- function(
 
     missing_vars <- c("statin_meds", "egfr_mlminm2", "bmi")[missing]
 
+    if(pred_type != 'hf') missing_vars <- setdiff(missing_vars, 'bmi')
+
     if(length(missing_vars) > 0){
 
       plural <- length(missing_vars > 1)

--- a/R/prevent.R
+++ b/R/prevent.R
@@ -31,6 +31,8 @@
   bp_meds = as.character(bp_meds)
   statin_meds = as.character(statin_meds)
 
+  if(is.null(bmi)) bmi <- rep(30, length(age_years))
+
   check_call(
     match.call(),
     expected = list(
@@ -122,14 +124,6 @@
   if(prevent_type %in% c("sdi", "full") && is.null(sdi)){
     stop("missing required variable: sdi")
   }
-
-  # coerce categorical data to character values ----
-
-  sex = as.character(sex)
-  smoke_current = as.character(smoke_current)
-  bp_meds = as.character(bp_meds)
-  statin_meds = as.character(statin_meds)
-  diabetes = as.character(diabetes)
 
   # recoding categorical variables ----
 

--- a/tests/testthat/test-predict_30yr_ascvd_risk.R
+++ b/tests/testthat/test-predict_30yr_ascvd_risk.R
@@ -11,7 +11,7 @@ test_that(
       bp_sys_mmhg = c(160, 160),
       diabetes = c("yes", "yes"),
       smoke_current = c("no", "no"),
-      bmi = c(35, 35),
+      # bmi = c(35, 35),
       egfr_mlminm2 = c(90, 90),
       bp_meds = c("yes", "yes"),
       statin_meds = c("no", "no"),


### PR DESCRIPTION
Fix #2 

bmi is only required for hf equations, so throwing an error when bmi is missing for, e.g., stroke, isn't helpful